### PR TITLE
Version 0.1.8

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@ go-sshlib
 A library to handle ssh easily with Golang.It can do multiple proxy, x11 forwarding, etc.
 Supported on Linux, macOS and Windows.
 
+If use **pkcs11** authentication, cgo must be enabled.
+
 * This program refactors the processing performed by lssh(https://github.com/blacknon/lssh) so that it can be treated as a library.
 
 ## Usage

--- a/auth_pkcs11.go
+++ b/auth_pkcs11.go
@@ -1,0 +1,88 @@
+// Copyright (c) 2021 Blacknon. All rights reserved.
+// Use of this source code is governed by an MIT license
+// that can be found in the LICENSE file.
+//go:build cgo
+// +build cgo
+
+package sshlib
+
+import (
+	"github.com/miekg/pkcs11/p11"
+	"golang.org/x/crypto/ssh"
+)
+
+// CreateAuthMethodPKCS11 return []ssh.AuthMethod generated from pkcs11 token.
+// PIN is required to generate a AuthMethod from a PKCS 11 token.
+// Not available if cgo is disabled.
+//
+// WORNING: Does not work if multiple tokens are stuck at the same time.
+func CreateAuthMethodPKCS11(provider, pin string) (auth []ssh.AuthMethod, err error) {
+	signers, err := CreateSignerPKCS11(provider, pin)
+	if err != nil {
+		return
+	}
+
+	for _, signer := range signers {
+		auth = append(auth, ssh.PublicKeys(signer))
+	}
+	return
+}
+
+// CreateSignerPKCS11 returns []ssh.Signer generated from PKCS11 token.
+// PIN is required to generate a Signer from a PKCS 11 token.
+// Not available if cgo is disabled.
+//
+// WORNING: Does not work if multiple tokens are stuck at the same time.
+func CreateSignerPKCS11(provider, pin string) (signers []ssh.Signer, err error) {
+	// get absolute path
+	provider = getAbsPath(provider)
+
+	// Create p11.module
+	module, err := p11.OpenModule(provider)
+	if err != nil {
+		return
+	}
+
+	// Get p11 Module's Slot
+	slots, err := module.Slots()
+	if err != nil {
+		return
+	}
+	c11array := []*C11{}
+
+	for _, slot := range slots {
+		tokenInfo, err := slot.TokenInfo()
+		if err != nil {
+			continue
+		}
+
+		c := &C11{
+			Label: tokenInfo.Label,
+			PIN:   pin,
+		}
+		c11array = append(c11array, c)
+	}
+
+	// Destroy Module
+	module.Destroy()
+
+	// for loop
+	for _, c11 := range c11array {
+		err := c11.CreateCtx(provider)
+		if err != nil {
+			continue
+		}
+
+		sigs, err := c11.GetSigner()
+		if err != nil {
+			continue
+		}
+
+		for _, sig := range sigs {
+			signer, _ := ssh.NewSignerFromSigner(sig)
+			signers = append(signers, signer)
+		}
+	}
+
+	return
+}

--- a/pkcs11.go
+++ b/pkcs11.go
@@ -1,6 +1,8 @@
 // Copyright (c) 2020 Blacknon. All rights reserved.
 // Use of this source code is governed by an MIT license
 // that can be found in the LICENSE file.
+//go:build cgo
+// +build cgo
 
 package sshlib
 
@@ -9,6 +11,7 @@ import (
 )
 
 // C11 struct for Crypto11 processing.
+// Not available if cgo is disabled.
 type C11 struct {
 	Label string
 	PIN   string
@@ -16,6 +19,7 @@ type C11 struct {
 }
 
 // getPIN is set token's PIN Code to c.PIN
+// Not available if cgo is disabled.
 func (c *C11) getPIN() (err error) {
 	if c.PIN == "" {
 		c.PIN, err = getPassphrase(c.Label + "'s PIN:")
@@ -25,6 +29,7 @@ func (c *C11) getPIN() (err error) {
 }
 
 // CreateCtx is create crypto11.Context
+// Not available if cgo is disabled.
 func (c *C11) CreateCtx(provider string) (err error) {
 	// Get PIN Code
 	err = c.getPIN()
@@ -47,7 +52,8 @@ func (c *C11) CreateCtx(provider string) (err error) {
 	return
 }
 
-// GetSigner return []crypto11.Signer
+// GetSigner return []crypto11.Signer.
+// Not available if cgo is disabled.
 func (c *C11) GetSigner() (signer []crypto11.Signer, err error) {
 	return c.Ctx.FindAllKeyPairs()
 }


### PR DESCRIPTION
update. #20 Allow builds to be done without cgo.
(pkcs11 related method cannot be used when cgo is disabled)