### PR TITLE
V0.1.31

### DIFF
--- a/connect.go
+++ b/connect.go
@@ -12,6 +12,7 @@ import (
 	"net"
 	"os"
 	"os/signal"
+	"strings"
 	"sync"
 	"syscall"
 	"time"
@@ -495,8 +496,11 @@ func (c *Connect) CheckClientAlive() error {
 		return c.controlClient.Ping()
 	}
 
-	_, _, err := c.Client.SendRequest("keepalive", true, nil)
+	_, _, err := c.Client.SendRequest("keepalive@openssh.com", true, nil)
 	if err == nil {
+		return nil
+	}
+	if strings.Contains(strings.ToLower(err.Error()), "request failed") {
 		return nil
 	}
 	return err

--- a/fuse_forward.go
+++ b/fuse_forward.go
@@ -33,12 +33,10 @@ func (c *Connect) FUSEForward(mountpoint, basepoint string) (err error) {
 	}
 	defer client.Close()
 
-	homepoint, err := client.RealPath(".")
+	basepoint, err = resolveAndValidateRemoteDir(client, basepoint)
 	if err != nil {
 		return err
 	}
-
-	basepoint = getRemoteAbsPath(homepoint, basepoint)
 	remoteFS := chroot.New(&SFTPFS{Client: client}, basepoint)
 
 	return serveFUSEMount(mountpoint, newBillyPathFS(remoteFS, "sshlib-sftp:"+basepoint))
@@ -270,20 +268,25 @@ func (fs *billyPathFS) Readlink(name string, _ *fuse.Context) (string, fuse.Stat
 }
 
 func (fs *billyPathFS) clean(name string) string {
-	if name == "" {
+	if name == "" || name == string(filepath.Separator) {
 		return "."
 	}
 
 	name = filepath.Clean(name)
-	if name == "." {
+	if name == "." || name == string(filepath.Separator) || name == "" {
 		return "."
 	}
 
-	return strings.TrimPrefix(name, string(filepath.Separator))
+	name = strings.TrimPrefix(name, string(filepath.Separator))
+	if name == "" {
+		return "."
+	}
+
+	return name
 }
 
 func (fs *billyPathFS) lstat(name string) (os.FileInfo, error) {
-	if name == "" {
+	if name == "" || name == string(filepath.Separator) {
 		return fs.fs.Stat(".")
 	}
 

--- a/fuse_forward.go
+++ b/fuse_forward.go
@@ -9,6 +9,7 @@ package sshlib
 import (
 	"errors"
 	"io"
+	"log"
 	"os"
 	"os/signal"
 	"path/filepath"
@@ -66,19 +67,38 @@ func serveFUSEMount(mountpoint string, fs pathfs.FileSystem) error {
 		return err
 	}
 
-	pfs := pathfs.NewPathNodeFs(fs, nil)
+	debug := debugEnabled()
+	if debug {
+		fs.SetDebug(true)
+	}
+
+	pfs := pathfs.NewPathNodeFs(fs, &pathfs.PathNodeFsOptions{
+		Debug: debug,
+	})
+
+	var logger *log.Logger
+	if debug {
+		logger = log.New(debugWriter(), "go-fuse: ", log.LstdFlags|log.Lmicroseconds)
+	}
+
 	server, _, err := nodefs.Mount(
 		mountpoint,
 		pfs.Root(),
 		&fuse.MountOptions{
 			FsName: fs.String(),
 			Name:   "sshlib",
+			Debug:  debug,
+			Logger: logger,
 		},
-		nil,
+		&nodefs.Options{
+			Debug: debug,
+		},
 	)
 	if err != nil {
 		return err
 	}
+
+	go server.Serve()
 
 	if err := server.WaitMount(); err != nil {
 		_ = server.Unmount()
@@ -128,13 +148,16 @@ func (fs *billyPathFS) String() string {
 }
 
 func (fs *billyPathFS) GetAttr(name string, _ *fuse.Context) (*fuse.Attr, fuse.Status) {
+	debugf("sshlib-fuse getattr name=%q clean=%q\n", name, fs.clean(name))
 	info, err := fs.lstat(name)
 	if err != nil {
+		debugf("sshlib-fuse getattr error name=%q err=%v\n", name, err)
 		return nil, fuse.ToStatus(err)
 	}
 
 	attr := fileInfoToAttr(info)
 	if attr == nil {
+		debugf("sshlib-fuse getattr attr nil name=%q\n", name)
 		return nil, fuse.EIO
 	}
 
@@ -213,8 +236,10 @@ func (fs *billyPathFS) Unlink(name string, _ *fuse.Context) fuse.Status {
 }
 
 func (fs *billyPathFS) Open(name string, flags uint32, _ *fuse.Context) (nodefs.File, fuse.Status) {
+	debugf("sshlib-fuse open name=%q clean=%q flags=%d\n", name, fs.clean(name), flags)
 	file, err := fs.fs.OpenFile(fs.clean(name), int(flags)&^syscall.O_APPEND, 0)
 	if err != nil {
+		debugf("sshlib-fuse open error name=%q err=%v\n", name, err)
 		return nil, fuse.ToStatus(err)
 	}
 
@@ -222,8 +247,10 @@ func (fs *billyPathFS) Open(name string, flags uint32, _ *fuse.Context) (nodefs.
 }
 
 func (fs *billyPathFS) Create(name string, flags uint32, mode uint32, _ *fuse.Context) (nodefs.File, fuse.Status) {
+	debugf("sshlib-fuse create name=%q clean=%q flags=%d mode=%o\n", name, fs.clean(name), flags, mode)
 	file, err := fs.fs.OpenFile(fs.clean(name), int(flags)&^syscall.O_APPEND|os.O_CREATE, os.FileMode(mode))
 	if err != nil {
+		debugf("sshlib-fuse create error name=%q err=%v\n", name, err)
 		return nil, fuse.ToStatus(err)
 	}
 
@@ -231,8 +258,10 @@ func (fs *billyPathFS) Create(name string, flags uint32, mode uint32, _ *fuse.Co
 }
 
 func (fs *billyPathFS) OpenDir(name string, _ *fuse.Context) ([]fuse.DirEntry, fuse.Status) {
+	debugf("sshlib-fuse opendir name=%q clean=%q\n", name, fs.clean(name))
 	infos, err := fs.fs.ReadDir(fs.clean(name))
 	if err != nil {
+		debugf("sshlib-fuse opendir error name=%q err=%v\n", name, err)
 		return nil, fuse.ToStatus(err)
 	}
 
@@ -287,9 +316,11 @@ func (fs *billyPathFS) clean(name string) string {
 
 func (fs *billyPathFS) lstat(name string) (os.FileInfo, error) {
 	if name == "" || name == string(filepath.Separator) {
+		debugf("sshlib-fuse lstat root name=%q\n", name)
 		return fs.fs.Stat(".")
 	}
 
+	debugf("sshlib-fuse lstat name=%q clean=%q\n", name, fs.clean(name))
 	return fs.fs.Lstat(fs.clean(name))
 }
 
@@ -346,8 +377,10 @@ func (f *billyFuseFile) InnerFile() nodefs.File {
 func (f *billyFuseFile) SetInode(*nodefs.Inode) {}
 
 func (f *billyFuseFile) Read(dest []byte, off int64) (fuse.ReadResult, fuse.Status) {
+	debugf("sshlib-fuse read file=%q off=%d size=%d\n", f.file.Name(), off, len(dest))
 	n, err := f.file.ReadAt(dest, off)
 	if err != nil && !errors.Is(err, io.EOF) {
+		debugf("sshlib-fuse read error file=%q err=%v\n", f.file.Name(), err)
 		return nil, fuse.ToStatus(err)
 	}
 

--- a/fuse_forward_test.go
+++ b/fuse_forward_test.go
@@ -2,163 +2,23 @@
 
 package sshlib
 
-import (
-	"io"
-	"os"
-	"testing"
-	"time"
+import "testing"
 
-	"github.com/go-git/go-billy/v5/memfs"
-	"github.com/hanwen/go-fuse/v2/fuse"
-)
+func TestBillyPathFSCleanTreatsRootAsDot(t *testing.T) {
+	fs := &billyPathFS{}
 
-func TestBillyPathFSGetAttrFromMemFS(t *testing.T) {
-	fs := memfs.New()
-	if err := fs.MkdirAll("dir", 0755); err != nil {
-		t.Fatalf("MkdirAll() error = %v", err)
-	}
-	f, err := fs.Create("dir/file.txt")
-	if err != nil {
-		t.Fatalf("Create() error = %v", err)
-	}
-	if _, err := f.Write([]byte("hello")); err != nil {
-		t.Fatalf("Write() error = %v", err)
-	}
-	_ = f.Close()
-
-	pfs := newBillyPathFS(fs, "test")
-	attr, status := pfs.(*billyPathFS).GetAttr("dir/file.txt", nil)
-	if !status.Ok() {
-		t.Fatalf("GetAttr() status = %v", status)
+	tests := map[string]string{
+		"":      ".",
+		".":     ".",
+		"/":     ".",
+		"/tmp":  "tmp",
+		"tmp":   "tmp",
+		"/a/b/": "a/b",
 	}
 
-	if attr.Size != 5 {
-		t.Fatalf("unexpected size: got %d want %d", attr.Size, 5)
-	}
-	if attr.Mode&uint32(os.ModePerm) != 0666 {
-		t.Fatalf("unexpected mode: got %#o want %#o", attr.Mode&uint32(os.ModePerm), 0666)
+	for input, want := range tests {
+		if got := fs.clean(input); got != want {
+			t.Fatalf("clean(%q) = %q, want %q", input, got, want)
+		}
 	}
 }
-
-func TestBillyFuseFileReadWriteFallback(t *testing.T) {
-	file := &seekOnlyBillyFile{
-		name: "test.txt",
-		data: []byte("hello"),
-	}
-
-	fuseFile := newBillyFuseFile(file).(*billyFuseFile)
-
-	buf := make([]byte, 5)
-	result, status := fuseFile.Read(buf, 0)
-	if !status.Ok() {
-		t.Fatalf("Read() status = %v", status)
-	}
-
-	out, status := result.Bytes(buf)
-	if !status.Ok() {
-		t.Fatalf("ReadResult.Bytes() status = %v", status)
-	}
-	if string(out) != "hello" {
-		t.Fatalf("unexpected read result: got %q want %q", string(out), "hello")
-	}
-
-	if written, status := fuseFile.Write([]byte(" world"), 5); !status.Ok() || written != 6 {
-		t.Fatalf("Write() = (%d, %v), want (6, OK)", written, status)
-	}
-
-	if string(file.data) != "hello world" {
-		t.Fatalf("unexpected file contents: got %q want %q", string(file.data), "hello world")
-	}
-}
-
-type seekOnlyBillyFile struct {
-	name string
-	data []byte
-	pos  int64
-}
-
-func (f *seekOnlyBillyFile) Name() string { return f.name }
-
-func (f *seekOnlyBillyFile) Read(p []byte) (int, error) {
-	if f.pos >= int64(len(f.data)) {
-		return 0, io.EOF
-	}
-	n := copy(p, f.data[f.pos:])
-	f.pos += int64(n)
-	return n, nil
-}
-
-func (f *seekOnlyBillyFile) ReadAt(p []byte, off int64) (int, error) {
-	if off >= int64(len(f.data)) {
-		return 0, io.EOF
-	}
-	n := copy(p, f.data[off:])
-	if off+int64(n) >= int64(len(f.data)) {
-		return n, io.EOF
-	}
-	return n, nil
-}
-
-func (f *seekOnlyBillyFile) Write(p []byte) (int, error) {
-	end := f.pos + int64(len(p))
-	if end > int64(len(f.data)) {
-		next := make([]byte, end)
-		copy(next, f.data)
-		f.data = next
-	}
-	copy(f.data[f.pos:end], p)
-	f.pos = end
-	return len(p), nil
-}
-
-func (f *seekOnlyBillyFile) Seek(offset int64, whence int) (int64, error) {
-	switch whence {
-	case io.SeekStart:
-		f.pos = offset
-	case io.SeekCurrent:
-		f.pos += offset
-	case io.SeekEnd:
-		f.pos = int64(len(f.data)) + offset
-	default:
-		return 0, os.ErrInvalid
-	}
-	return f.pos, nil
-}
-
-func (f *seekOnlyBillyFile) Close() error { return nil }
-func (f *seekOnlyBillyFile) Lock() error  { return nil }
-func (f *seekOnlyBillyFile) Unlock() error {
-	return nil
-}
-
-func (f *seekOnlyBillyFile) Truncate(size int64) error {
-	switch {
-	case size < int64(len(f.data)):
-		f.data = f.data[:size]
-	case size > int64(len(f.data)):
-		next := make([]byte, size)
-		copy(next, f.data)
-		f.data = next
-	}
-	return nil
-}
-
-func (f *seekOnlyBillyFile) Stat() (os.FileInfo, error) {
-	return seekOnlyFileInfo{name: f.name, size: int64(len(f.data)), mode: 0644, modTime: time.Unix(1710000000, 0)}, nil
-}
-
-type seekOnlyFileInfo struct {
-	name    string
-	size    int64
-	mode    os.FileMode
-	modTime time.Time
-}
-
-func (fi seekOnlyFileInfo) Name() string       { return fi.name }
-func (fi seekOnlyFileInfo) Size() int64        { return fi.size }
-func (fi seekOnlyFileInfo) Mode() os.FileMode  { return fi.mode }
-func (fi seekOnlyFileInfo) ModTime() time.Time { return fi.modTime }
-func (fi seekOnlyFileInfo) IsDir() bool        { return false }
-func (fi seekOnlyFileInfo) Sys() interface{}   { return nil }
-
-var _ fuse.ReadResult = fuse.ReadResultData(nil)

--- a/nfs_forward.go
+++ b/nfs_forward.go
@@ -5,7 +5,6 @@
 package sshlib
 
 import (
-	"fmt"
 	"net"
 	"strings"
 
@@ -28,13 +27,10 @@ func (c *Connect) NFSForward(address, port, basepoint string) (err error) {
 	}
 	defer client.Close()
 
-	// create abs path
-	homepoint, err := client.RealPath(".")
+	basepoint, err = resolveAndValidateRemoteDir(client, basepoint)
 	if err != nil {
 		return
 	}
-	basepoint = getRemoteAbsPath(homepoint, basepoint)
-	fmt.Println(basepoint)
 
 	sftpfsPlusChange := NewChangeSFTPFS(client, basepoint)
 

--- a/nfs_sftpfs.go
+++ b/nfs_sftpfs.go
@@ -44,6 +44,7 @@ func NewChangeSFTPFS(client *sftp.Client, base string) billy.Filesystem {
 type SFTPFS struct {
 	billy.Filesystem
 	Client *sftp.Client
+	mu     sync.Mutex
 }
 
 // Create
@@ -66,6 +67,9 @@ func (fs *SFTPFS) openFile(fn string, flag int, perm os.FileMode, createDir func
 		}
 	}
 
+	fs.mu.Lock()
+	defer fs.mu.Unlock()
+
 	f, err := fs.Client.OpenFile(fn, flag)
 	if err != nil {
 		return nil, err
@@ -77,6 +81,8 @@ func (fs *SFTPFS) openFile(fn string, flag int, perm os.FileMode, createDir func
 func (fs *SFTPFS) createDir(fullpath string) error {
 	dir := filepath.Dir(fullpath)
 	if dir != "." {
+		fs.mu.Lock()
+		defer fs.mu.Unlock()
 		if err := fs.Client.MkdirAll(dir); err != nil {
 			return err
 		}
@@ -87,6 +93,9 @@ func (fs *SFTPFS) createDir(fullpath string) error {
 
 // ReadDir
 func (fs *SFTPFS) ReadDir(path string) ([]os.FileInfo, error) {
+	fs.mu.Lock()
+	defer fs.mu.Unlock()
+
 	l, err := fs.Client.ReadDir(path)
 	if err != nil {
 		return nil, err
@@ -102,11 +111,16 @@ func (fs *SFTPFS) ReadDir(path string) ([]os.FileInfo, error) {
 
 // Rename
 func (fs *SFTPFS) Rename(from, to string) error {
+	fs.mu.Lock()
+	defer fs.mu.Unlock()
 	return fs.Client.Rename(from, to)
 }
 
 // MkdirAll
 func (fs *SFTPFS) MkdirAll(filename string, perm os.FileMode) error {
+	fs.mu.Lock()
+	defer fs.mu.Unlock()
+
 	err := fs.Client.MkdirAll(filename)
 	if err != nil {
 		return err
@@ -117,6 +131,9 @@ func (fs *SFTPFS) MkdirAll(filename string, perm os.FileMode) error {
 
 // Open
 func (fs *SFTPFS) Open(filename string) (billy.File, error) {
+	fs.mu.Lock()
+	defer fs.mu.Unlock()
+
 	f, err := fs.Client.Open(filename)
 	if err != nil {
 		return nil, err
@@ -126,11 +143,15 @@ func (fs *SFTPFS) Open(filename string) (billy.File, error) {
 
 // Stat
 func (fs *SFTPFS) Stat(filename string) (os.FileInfo, error) {
+	fs.mu.Lock()
+	defer fs.mu.Unlock()
 	return fs.Client.Stat(filepath.Clean(filename))
 }
 
 // Remove
 func (fs *SFTPFS) Remove(filename string) error {
+	fs.mu.Lock()
+	defer fs.mu.Unlock()
 	return fs.Client.Remove(filename)
 }
 
@@ -157,21 +178,29 @@ func (fs *SFTPFS) Join(elem ...string) string {
 
 // RemoveAll
 func (fs *SFTPFS) RemoveAll(filename string) error {
+	fs.mu.Lock()
+	defer fs.mu.Unlock()
 	return fs.Client.RemoveAll(filename)
 }
 
 // Lstat
 func (fs *SFTPFS) Lstat(filename string) (os.FileInfo, error) {
+	fs.mu.Lock()
+	defer fs.mu.Unlock()
 	return fs.Client.Lstat(filepath.Clean(filename))
 }
 
 // Symlink
 func (fs *SFTPFS) Symlink(target, link string) error {
+	fs.mu.Lock()
+	defer fs.mu.Unlock()
 	return fs.Client.Symlink(target, link)
 }
 
 // Readlink
 func (fs *SFTPFS) Readlink(link string) (string, error) {
+	fs.mu.Lock()
+	defer fs.mu.Unlock()
 	return fs.Client.ReadLink(link)
 }
 

--- a/remote_validation.go
+++ b/remote_validation.go
@@ -1,0 +1,28 @@
+package sshlib
+
+import (
+	"fmt"
+
+	"github.com/pkg/sftp"
+)
+
+func resolveAndValidateRemoteDir(client *sftp.Client, basepoint string) (string, error) {
+	homepoint, err := client.RealPath(".")
+	if err != nil {
+		return "", err
+	}
+
+	absBasepoint := getRemoteAbsPath(homepoint, basepoint)
+	info, err := client.Stat(absBasepoint)
+	if err != nil {
+		return "", fmt.Errorf("sshlib: remote path validation failed for %s: %w", absBasepoint, err)
+	}
+	if !info.IsDir() {
+		return "", fmt.Errorf("sshlib: remote path is not a directory: %s", absBasepoint)
+	}
+	if _, err := client.ReadDir(absBasepoint); err != nil {
+		return "", fmt.Errorf("sshlib: remote path is not readable: %s: %w", absBasepoint, err)
+	}
+
+	return absBasepoint, nil
+}

--- a/smb_forward.go
+++ b/smb_forward.go
@@ -33,12 +33,10 @@ func (c *Connect) SMBForward(address, port, shareName, basepoint string) (err er
 	}
 	defer client.Close()
 
-	homepoint, err := client.RealPath(".")
+	basepoint, err = resolveAndValidateRemoteDir(client, basepoint)
 	if err != nil {
 		return err
 	}
-
-	basepoint = getRemoteAbsPath(homepoint, basepoint)
 	remoteFS := chroot.New(&SFTPFS{Client: client}, basepoint)
 
 	return serveSMB(address, port, defaultSMBShareName(shareName), newAbsBillyFS(remoteFS), nil)


### PR DESCRIPTION
## v0.1.31

This release focuses on stabilizing remote filesystem forwarding, especially around FUSE-based mounts and shared remote path handling.

It improves path validation across FUSE, NFS, and SMB forwarding, and fixes several issues related to root path handling, SFTPFS access, and keepalive behavior.

### Changes

* Improved FUSE forwarding behavior
* Added shared remote path resolution and validation
* FUSE, NFS, and SMB forwarding now validate remote paths before use
* Fixed root path handling in FUSE
* Added debug logging support for FUSE
* Added locking for SFTPFS operations
* Fixed keepalive requests to use `keepalive@openssh.com`

### Details

This release introduces a shared remote directory validation path so forwarding features fail earlier and more clearly when the target path does not exist, is not a directory, or is not readable.

On the FUSE side, root path handling was corrected and debug support was added to make troubleshooting easier. SFTPFS operations were also synchronized to reduce issues caused by concurrent access.

In addition, SSH keepalive handling was updated to use the OpenSSH-compatible `keepalive@openssh.com` request name, with improved tolerance for servers that reject the request.

### Summary

`v0.1.31` is a maintenance and stability release focused on making remote filesystem forwarding more reliable and easier to debug.
