### PR TITLE
Version 0.1.33

### DIFF
--- a/auth.go
+++ b/auth.go
@@ -39,8 +39,9 @@ type ControlPersistAuthMethod struct {
 
 	Password string
 
-	KeyPath string
-	KeyPass string
+	KeyPath   string
+	KeyPass   string
+	Transient bool
 
 	PKCS11Provider string
 	PKCS11PIN      string
@@ -56,8 +57,9 @@ type controlPersistAuthMethodDefinition struct {
 
 	Password string
 
-	KeyPath string
-	KeyPass string
+	KeyPath   string
+	KeyPass   string
+	Transient bool
 
 	PKCS11Provider string
 	PKCS11PIN      string
@@ -78,6 +80,7 @@ func (a *ControlPersistAuth) resolved() ([]controlPersistAuthMethodDefinition, e
 				Password:       method.Password,
 				KeyPath:        method.KeyPath,
 				KeyPass:        method.KeyPass,
+				Transient:      method.Transient,
 				PKCS11Provider: method.PKCS11Provider,
 				PKCS11PIN:      method.PKCS11PIN,
 			})
@@ -112,6 +115,11 @@ func createControlPersistAuthMethodsWithPrompt(definitions []controlPersistAuthM
 		return nil, err
 	}
 
+	transientKeyPaths := make([]string, 0, len(definitions))
+	defer func() {
+		cleanupControlPersistTransientFiles(transientKeyPaths)
+	}()
+
 	authMethods := make([]ssh.AuthMethod, 0, len(definitions))
 	for _, persistAuth := range definitions {
 		switch persistAuth.Type {
@@ -121,6 +129,9 @@ func createControlPersistAuthMethodsWithPrompt(definitions []controlPersistAuthM
 			auth, err := CreateAuthMethodPublicKey(persistAuth.KeyPath, persistAuth.KeyPass)
 			if err != nil {
 				return nil, err
+			}
+			if persistAuth.Transient {
+				transientKeyPaths = append(transientKeyPaths, persistAuth.KeyPath)
 			}
 			authMethods = append(authMethods, auth)
 		case "pkcs11":
@@ -135,6 +146,27 @@ func createControlPersistAuthMethodsWithPrompt(definitions []controlPersistAuthM
 	}
 
 	return authMethods, nil
+}
+
+func cleanupControlPersistTransientFiles(paths []string) {
+	if len(paths) == 0 {
+		return
+	}
+
+	seen := make(map[string]struct{}, len(paths))
+	for _, path := range paths {
+		if path == "" {
+			continue
+		}
+
+		absPath := getAbsPath(path)
+		if _, ok := seen[absPath]; ok {
+			continue
+		}
+		seen[absPath] = struct{}{}
+
+		_ = os.Remove(absPath)
+	}
 }
 
 func validateControlPersistAuthDefinitions(definitions []controlPersistAuthMethodDefinition) error {
@@ -221,6 +253,17 @@ func CreateAuthMethodPassword(password string) (auth ssh.AuthMethod) {
 // CreateAuthMethodPublicKey returns ssh.AuthMethod generated from PublicKey.
 // If you have not specified a passphrase, please specify a empty character("").
 func CreateAuthMethodPublicKey(key, password string) (auth ssh.AuthMethod, err error) {
+	return createAuthMethodPublicKey(key, password, false)
+}
+
+// CreateAuthMethodPublicKeyTransient returns ssh.AuthMethod generated from PublicKey.
+// The serialized ControlPersist definition is marked as transient, so detached
+// helpers remove the key file after rebuilding the signer in memory.
+func CreateAuthMethodPublicKeyTransient(key, password string) (auth ssh.AuthMethod, err error) {
+	return createAuthMethodPublicKey(key, password, true)
+}
+
+func createAuthMethodPublicKey(key, password string, transient bool) (auth ssh.AuthMethod, err error) {
 	signer, err := CreateSignerPublicKey(key, password)
 	if err != nil {
 		return
@@ -228,9 +271,10 @@ func CreateAuthMethodPublicKey(key, password string) (auth ssh.AuthMethod, err e
 
 	auth = ssh.PublicKeys(signer)
 	registerControlPersistAuthMethod(auth, controlPersistAuthMethodDefinition{
-		Type:    "publickey",
-		KeyPath: key,
-		KeyPass: password,
+		Type:      "publickey",
+		KeyPath:   key,
+		KeyPass:   password,
+		Transient: transient,
 	})
 	return
 }

--- a/auth_test.go
+++ b/auth_test.go
@@ -1,6 +1,12 @@
 package sshlib
 
 import (
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"encoding/pem"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -83,4 +89,67 @@ func TestCreateControlPersistAuthMethodsRejectsUnsupportedType(t *testing.T) {
 	if !strings.Contains(err.Error(), "unsupported ControlPersistAuth type") {
 		t.Fatalf("createControlPersistAuthMethods() error = %v, want unsupported ControlPersistAuth type", err)
 	}
+}
+
+func TestCreateAuthMethodPublicKeyTransientMarksDefinition(t *testing.T) {
+	keyPath := writeTempPrivateKey(t)
+
+	authMethod, err := CreateAuthMethodPublicKeyTransient(keyPath, "")
+	if err != nil {
+		t.Fatalf("CreateAuthMethodPublicKeyTransient() error = %v", err)
+	}
+
+	resolved, err := (&ControlPersistAuth{AuthMethods: []ssh.AuthMethod{authMethod}}).resolved()
+	if err != nil {
+		t.Fatalf("resolved() error = %v", err)
+	}
+
+	if len(resolved) != 1 {
+		t.Fatalf("len(resolved) = %d, want 1", len(resolved))
+	}
+	if !resolved[0].Transient {
+		t.Fatal("resolved[0].Transient = false, want true")
+	}
+}
+
+func TestCreateControlPersistAuthMethodsRemovesTransientKeyFile(t *testing.T) {
+	keyPath := writeTempPrivateKey(t)
+
+	authMethods, err := createControlPersistAuthMethods([]controlPersistAuthMethodDefinition{{
+		Type:      "publickey",
+		KeyPath:   keyPath,
+		Transient: true,
+	}})
+	if err != nil {
+		t.Fatalf("createControlPersistAuthMethods() error = %v", err)
+	}
+	if len(authMethods) != 1 {
+		t.Fatalf("len(authMethods) = %d, want 1", len(authMethods))
+	}
+
+	if _, err := os.Stat(keyPath); !os.IsNotExist(err) {
+		t.Fatalf("transient key file still exists: stat err = %v", err)
+	}
+}
+
+func writeTempPrivateKey(t *testing.T) string {
+	t.Helper()
+
+	privateKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatalf("rsa.GenerateKey() error = %v", err)
+	}
+
+	privateKeyPEM := pem.EncodeToMemory(&pem.Block{
+		Type:  "RSA PRIVATE KEY",
+		Bytes: x509.MarshalPKCS1PrivateKey(privateKey),
+	})
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "id_rsa")
+	if err := os.WriteFile(path, privateKeyPEM, 0o600); err != nil {
+		t.Fatalf("os.WriteFile() error = %v", err)
+	}
+
+	return path
 }

--- a/common.go
+++ b/common.go
@@ -18,9 +18,22 @@ import (
 // getAbsPath return absolute path convert.
 // Replace `~` with your home directory.
 func getAbsPath(path string) string {
-	// Replace home directory
-	usr, _ := user.Current()
-	path = strings.Replace(path, "~", usr.HomeDir, 1)
+	// Replace a leading home-directory marker only.
+	// On Windows, paths may legitimately contain `~` as part of an 8.3 short name
+	// such as `RUNNERC~1`, so replacing arbitrary `~` characters corrupts the path.
+	if path == "~" || strings.HasPrefix(path, "~"+string(filepath.Separator)) || strings.HasPrefix(path, "~/") || strings.HasPrefix(path, "~\\") {
+		usr, _ := user.Current()
+		if usr != nil {
+			switch {
+			case path == "~":
+				path = usr.HomeDir
+			case strings.HasPrefix(path, "~/"), strings.HasPrefix(path, "~\\"):
+				path = filepath.Join(usr.HomeDir, path[2:])
+			default:
+				path = usr.HomeDir + path[1:]
+			}
+		}
+	}
 
 	path, _ = filepath.Abs(path)
 	return path


### PR DESCRIPTION
## v0.1.33

Released `go-sshlib` v0.1.33, the SSH library for `lssh`.

This release improves `ControlPersist` handling for temporary private key files.

### Changes

- Added support for transient public key authentication in `ControlPersist`
- Added `CreateAuthMethodPublicKeyTransient()` for public key auth that is intended to be temporary
- Marked transient key definitions so detached `ControlPersist` helpers can rebuild the signer and then remove the source key file
- Added cleanup logic to remove transient key files after `ControlPersist` auth methods are reconstructed
- Added tests covering transient key serialization and cleanup behavior

### Purpose

- Improve handling of temporary private keys used with `ControlPersist`
- Reduce the chance of leaving transient key material on disk longer than necessary
- Make detached `ControlPersist` helper behavior safer and more predictable

If you want, I can also rewrite this into:
- a shorter GitHub Releases version
- a more technical changelog-style version
- a Japanese/English bilingual version